### PR TITLE
fix: 修复手动确认阶段后 status 仍显示 unknown

### DIFF
--- a/super_dev/cli.py
+++ b/super_dev/cli.py
@@ -905,12 +905,19 @@ class SuperDevCLI(
         ui_state = self._get_ui_revision_state(project_dir)
         architecture_state = self._get_architecture_revision_state(project_dir)
         quality_state = self._get_quality_revision_state(project_dir)
+        effective_status = self._effective_run_status(
+            run_state=run_state,
+            docs_state=docs_state,
+            ui_state=ui_state,
+            architecture_state=architecture_state,
+            quality_state=quality_state,
+        )
         phase_confirmations = {}
         if isinstance(run_state.get("phase_confirmations"), dict):
             phase_confirmations = dict(run_state.get("phase_confirmations") or {})
         payload = {
             "run_state_exists": bool(run_state),
-            "status": str(run_state.get("status", "")).strip() or "unknown",
+            "status": effective_status,
             "description": str(
                 (run_state.get("pipeline_args") or {}).get("description", "")
             ).strip(),
@@ -1047,6 +1054,8 @@ class SuperDevCLI(
         phase_confirmations = run_state.get("phase_confirmations")
         if not isinstance(phase_confirmations, dict):
             phase_confirmations = {}
+        if not str(run_state.get("status", "")).strip():
+            run_state["status"] = "running"
         phase_confirmations[normalized] = {
             "status": "confirmed",
             "comment": comment or f"{normalized} 阶段确认通过",
@@ -1204,6 +1213,34 @@ class SuperDevCLI(
         self.console.print(f"[cyan]将从第 {stage_number} 阶段继续执行...[/cyan]")
         return self._cmd_run_resume(argparse.Namespace(resume=True))
 
+    def _effective_run_status(
+        self,
+        *,
+        run_state: dict[str, Any],
+        docs_state: dict[str, Any],
+        ui_state: dict[str, Any],
+        architecture_state: dict[str, Any],
+        quality_state: dict[str, Any],
+    ) -> str:
+        explicit_status = str(run_state.get("status", "")).strip().lower()
+        if explicit_status:
+            return explicit_status
+
+        normalized_status = str(run_state.get("status_normalized", "")).strip().lower()
+        if normalized_status and normalized_status != "unknown":
+            return normalized_status
+
+        phase_confirmations = run_state.get("phase_confirmations")
+        has_phase_confirmations = isinstance(phase_confirmations, dict) and bool(phase_confirmations)
+        review_states = (docs_state, ui_state, architecture_state, quality_state)
+        has_review_evidence = any(
+            bool(state.get("exists")) or str(state.get("status", "")).strip() not in {"", "pending_review"}
+            for state in review_states
+        )
+        if has_phase_confirmations or has_review_evidence:
+            return "running"
+        return "unknown"
+
     def _run_status_recommendation(
         self,
         *,
@@ -1224,9 +1261,15 @@ class SuperDevCLI(
             return 'super-dev review architecture --status confirmed --comment "架构返工已通过"'
         if quality_state.get("status") == "revision_requested":
             return 'super-dev review quality --status confirmed --comment "质量返工已通过"'
-        status = str(run_state.get("status", "")).strip().lower()
+        status = self._effective_run_status(
+            run_state=run_state,
+            docs_state=docs_state,
+            ui_state=ui_state,
+            architecture_state=architecture_state,
+            quality_state=quality_state,
+        )
         skipped_gates = list(run_state.get("skipped_gates") or [])
-        scope_status = str(run_state.get("scope_coverage_status", "")).strip().lower()
+        scope_status = str(run_state.get("scope_coverage_status", "")).strip().lower() or "unknown"
         high_priority_scope_gaps = int(run_state.get("scope_high_priority_gap_count", 0) or 0)
         if scope_status in {"partial", "unknown"} or high_priority_scope_gaps > 0:
             return "super-dev feature-checklist"

--- a/tests/unit/test_cli_resume.py
+++ b/tests/unit/test_cli_resume.py
@@ -200,6 +200,61 @@ def test_run_confirm_phase_updates_run_state_for_generic_phase(temp_project_dir,
     assert confirmations["frontend"]["status"] == "confirmed"
 
 
+def test_run_confirm_phase_initializes_status_when_missing(temp_project_dir, monkeypatch) -> None:
+    cli = SuperDevCLI()
+    monkeypatch.chdir(temp_project_dir)
+
+    code = cli._cmd_run_confirm_phase(
+        phase_name="frontend",
+        comment="前端预览已通过",
+        actor="tester",
+    )
+    assert code == 0
+
+    run_state = cli._read_pipeline_run_state(temp_project_dir) or {}
+    assert run_state["status"] == "running"
+    assert run_state["status_normalized"] == "running"
+
+
+def test_run_status_recommendation_treats_missing_scope_status_as_unknown() -> None:
+    cli = SuperDevCLI()
+
+    recommendation = cli._run_status_recommendation(
+        run_state={"status": "running"},
+        docs_state={"status": "confirmed"},
+        preview_state={"status": "confirmed"},
+        ui_state={"status": "confirmed"},
+        architecture_state={"status": "confirmed"},
+        quality_state={"status": "confirmed"},
+    )
+
+    assert recommendation == "super-dev feature-checklist"
+
+
+def test_run_status_uses_running_for_existing_confirmation_only_state(
+    temp_project_dir, monkeypatch, capsys
+) -> None:
+    cli = SuperDevCLI()
+    monkeypatch.chdir(temp_project_dir)
+    cli._write_pipeline_run_state(
+        temp_project_dir,
+        {
+            "phase_confirmations": {
+                "frontend": {
+                    "status": "confirmed",
+                    "actor": "tester",
+                }
+            }
+        },
+    )
+
+    code = cli._cmd_run_status(type("Args", (), {"json": True})())
+
+    assert code == 0
+    output = capsys.readouterr().out
+    assert '"status": "running"' in output
+
+
 def test_status_alias_routes_to_run_status(monkeypatch) -> None:
     cli = SuperDevCLI()
     called = {"status": False}


### PR DESCRIPTION
## 背景

  修复一个 `super-dev status` 状态显示不准确的问题。

  在某些场景下，手动执行 `super-dev confirm frontend/
  backend/delivery` 后，
  `.super-dev/runs/last-pipeline.json` 里只有
  `phase_confirmations`，却没有顶层 `status`。
  这会导致 `super-dev status` 仍然显示 `unknown`，即使仓
  库里已经存在明确的阶段确认和 review-state 证据。

  ## 本次修改

  - 当执行通用阶段确认（如 `frontend` / `backend` /
  `delivery`）且当前 run-state 没有 `status` 时，自动补上
  `status = running`
  - 增加 `_effective_run_status(...)`，让 `super-dev
  status` 在遇到旧格式或不完整 run-state 时，可以根据
  `phase_confirmations` 和 review-state 回退推断状态
  - 当 `scope_coverage_status` 缺失时，按 `unknown` 处
  理，避免错误地推荐 `super-dev run --phase frontend`

  ## 问题表现

  此前可能出现这样的链路：

  1. 仓库里已经有阶段确认信息，但顶层 `status` 没有落盘
  2. 再执行一次 `super-dev confirm frontend/backend/
  delivery`
  3. `super-dev status` 依然显示 `运行状态: unknown`

  这会导致 CLI 展示状态和仓库中的真实流程证据不一致。

  ## 测试

  补充了回归测试，覆盖以下场景：

  - 在没有 run status 的情况下执行通用阶段确认
  - 在 `scope_coverage_status` 缺失时计算
  `recommended_next`
  - 对只有 `phase_confirmations`、没有顶层 `status` 的旧
  run-state，`status` 应回退为 `running`

  ## 验证

  本地执行：

  ```bash
  python3 -m pytest -q tests/unit/test_cli_resume.py
