### PR TITLE
[codex] feat(design): add design inspiration workflow for uiux generation

### DIFF
--- a/super_dev/cli.py
+++ b/super_dev/cli.py
@@ -1338,6 +1338,7 @@ class SuperDevCLI(
             style_solution=config.style_solution,
             state_management=list(config.state_management or []),
             testing_frameworks=list(config.testing_frameworks or []),
+            design_inspiration_slug=str(getattr(config, "design_inspiration_slug", "") or ""),
             language_preferences=list(config.language_preferences or []),
             knowledge_summary=knowledge_summary,
         )
@@ -2794,6 +2795,9 @@ class SuperDevCLI(
                     frontend=args.frontend,
                     backend=args.backend,
                     domain=args.domain,
+                    design_inspiration_slug=str(
+                        getattr(pipeline_config, "design_inspiration_slug", "") or ""
+                    ),
                     language_preferences=pipeline_config.language_preferences,
                     knowledge_summary=(
                         knowledge_bundle.get("research_summary", {})

--- a/super_dev/cli_experience_mixin.py
+++ b/super_dev/cli_experience_mixin.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 from .catalogs import (
@@ -14,7 +15,7 @@ from .catalogs import (
     PIPELINE_FRONTEND_TEMPLATE_IDS,
     PLATFORM_IDS,
 )
-from .config import ConfigManager
+from .config import ConfigManager, get_config_manager
 
 SUPPORTED_PLATFORMS = list(PLATFORM_IDS)
 SUPPORTED_PIPELINE_FRONTENDS = list(PIPELINE_FRONTEND_TEMPLATE_IDS)
@@ -292,9 +293,205 @@ class CliExperienceMixin:
 
         return 0
 
+    def _resolve_design_command_context(
+        self,
+        *,
+        idea: str = "",
+        frontend: str = "",
+        product_type: str = "",
+        industry: str = "",
+        style: str = "",
+    ) -> dict[str, object]:
+        project_dir = Path.cwd()
+        config_manager = get_config_manager(project_dir)
+        config = config_manager.load()
+
+        config_exists = config_manager.exists()
+        base_name = str(config.name or "").strip() if config_exists else project_dir.name
+        if not base_name:
+            base_name = project_dir.name or "my-project"
+        project_name = self._sanitize_project_name(base_name)
+        description = str(idea or "").strip() or str(config.description or "").strip() or project_name
+        platform_value = str(config.platform or "web").strip() or "web"
+        frontend_value = str(frontend or config.frontend or "next").strip() or "next"
+        backend_value = str(config.backend or "node").strip() or "node"
+        domain_value = str(config.domain or "").strip()
+
+        from .creators import DocumentGenerator
+
+        generator = DocumentGenerator(
+            name=project_name,
+            description=description,
+            platform=platform_value,
+            frontend=frontend_value,
+            backend=backend_value,
+            domain=domain_value,
+            ui_library=config.ui_library,
+            style_solution=config.style_solution,
+            state_management=list(config.state_management or []),
+            testing_frameworks=list(config.testing_frameworks or []),
+            design_inspiration_slug=str(getattr(config, "design_inspiration_slug", "") or ""),
+            language_preferences=list(config.language_preferences or []),
+        )
+        analysis = generator._analyze_project_for_design()
+        if product_type:
+            analysis["product_type"] = product_type.strip().lower()
+        if industry:
+            analysis["industry"] = industry.strip().lower()
+        if style:
+            analysis["style"] = style.strip().lower()
+
+        return {
+            "project_dir": project_dir,
+            "project_name": project_name,
+            "description": description,
+            "platform": platform_value,
+            "frontend": frontend_value,
+            "backend": backend_value,
+            "domain": domain_value,
+            "analysis": analysis,
+            "config_manager": config_manager,
+            "config_exists": config_exists,
+        }
+
+    def _render_design_inspiration_list(self, inspirations: list[dict[str, object]]) -> None:
+        if not inspirations:
+            self.console.print("[yellow]未找到匹配的设计灵感锚点[/yellow]")
+            return
+
+        self.console.print(f"[green]设计灵感锚点 ({len(inspirations)} 个):[/green]\n")
+        for idx, item in enumerate(inspirations, 1):
+            signals = " / ".join(str(signal) for signal in list(item.get("signals", []))[:3])
+            self.console.print(
+                f"[cyan]{idx}. {item.get('name', 'N/A')}[/cyan]  [dim]slug={item.get('slug', 'N/A')}[/dim]"
+            )
+            self.console.print(f"    方向: {item.get('direction', 'N/A')}")
+            self.console.print(f"    理由: {item.get('rationale', 'N/A')}")
+            if signals:
+                self.console.print(f"    参考信号: {signals}")
+            source = str(item.get("source", "")).strip()
+            if source:
+                self.console.print(f"    来源: {source}")
+            self.console.print()
+
     def _cmd_design(self, args) -> int:
         """设计智能引擎命令"""
-        from .design import DesignIntelligenceEngine, DesignSystemGenerator, TokenGenerator
+        from .design import (
+            DesignIntelligenceEngine,
+            DesignSystemGenerator,
+            TokenGenerator,
+            UIIntelligenceAdvisor,
+        )
+
+        if args.design_command == "list":
+            advisor = UIIntelligenceAdvisor()
+            inspirations = [
+                item.to_dict()
+                for item in advisor.list_design_references(
+                    product_type=str(getattr(args, "product_type", "") or "").strip().lower() or None,
+                    industry=str(getattr(args, "industry", "") or "").strip().lower() or None,
+                    style=str(getattr(args, "style", "") or "").strip().lower() or None,
+                    frontend=str(getattr(args, "frontend", "") or "").strip() or None,
+                    limit=max(int(getattr(args, "max_results", 10) or 10), 1),
+                )
+            ]
+            self._render_design_inspiration_list(inspirations)
+            return 0
+
+        if args.design_command == "recommend":
+            advisor = UIIntelligenceAdvisor()
+            context = self._resolve_design_command_context(
+                idea=str(getattr(args, "idea", "") or ""),
+                frontend=str(getattr(args, "frontend", "") or ""),
+                product_type=str(getattr(args, "product_type", "") or ""),
+                industry=str(getattr(args, "industry", "") or ""),
+                style=str(getattr(args, "style", "") or ""),
+            )
+            analysis = context["analysis"]
+            if not isinstance(analysis, dict):
+                self.console.print("[red]无法解析当前项目的设计上下文[/red]")
+                return 1
+
+            profile = advisor.recommend(
+                description=str(context["description"]),
+                frontend=str(context["frontend"]),
+                product_type=str(analysis.get("product_type", "general")),
+                industry=str(analysis.get("industry", "general")),
+                style=str(analysis.get("style", "modern")),
+            )
+            inspirations = [
+                item
+                for item in list(profile.get("design_references", []))[: max(int(getattr(args, "max_results", 3) or 3), 1)]
+                if isinstance(item, dict)
+            ]
+
+            self.console.print("[cyan]设计灵感推荐[/cyan]")
+            self.console.print(
+                f"  项目: {context['project_name']} | 前端: {context['frontend']} | 产品类型: {analysis.get('product_type', 'general')}"
+            )
+            self.console.print(
+                f"  行业: {analysis.get('industry', 'general')} | 风格: {analysis.get('style', 'modern')}"
+            )
+            self.console.print("  真源: 内部仍以 output/*-uiux.md + output/*-ui-contract.json 为准\n")
+            self._render_design_inspiration_list(inspirations)
+            return 0
+
+        if args.design_command == "apply":
+            advisor = UIIntelligenceAdvisor()
+            selected = advisor.get_design_reference(args.slug)
+            if selected is None:
+                self.console.print(f"[red]未知设计灵感 slug: {args.slug}[/red]")
+                self.console.print("[dim]先运行 `super-dev design list` 查看可用 slug[/dim]")
+                return 1
+
+            context = self._resolve_design_command_context(idea=str(getattr(args, "idea", "") or ""))
+            config_manager = context["config_manager"]
+            if not isinstance(config_manager, ConfigManager):
+                self.console.print("[red]无法加载项目配置管理器[/red]")
+                return 1
+
+            if not bool(context["config_exists"]):
+                config_manager.create(
+                    name=str(context["project_name"]),
+                    description=str(context["description"]),
+                    platform=str(context["platform"]),
+                    frontend=str(context["frontend"]),
+                    backend=str(context["backend"]),
+                    domain=str(context["domain"]),
+                )
+
+            update_payload: dict[str, object] = {"design_inspiration_slug": selected.slug}
+            if str(getattr(args, "idea", "") or "").strip() and not str(config_manager.config.description or "").strip():
+                update_payload["description"] = str(getattr(args, "idea", "")).strip()
+            updated_config = config_manager.update(**update_payload)
+
+            output_dir = Path.cwd() / str(updated_config.output_dir or "output")
+            output_dir.mkdir(parents=True, exist_ok=True)
+            project_name = self._sanitize_project_name(str(updated_config.name or context["project_name"]))
+            record_path = output_dir / f"{project_name}-design-inspiration.json"
+            record_payload = {
+                "slug": selected.slug,
+                "name": selected.name,
+                "rationale": selected.rationale,
+                "direction": selected.direction,
+                "source": selected.source,
+                "signals": list(selected.signals),
+                "cautions": list(selected.cautions),
+                "applied_at": datetime.now(timezone.utc).isoformat(),
+            }
+            record_path.write_text(
+                json.dumps(record_payload, ensure_ascii=False, indent=2),
+                encoding="utf-8",
+            )
+
+            self.console.print(f"[green]✓[/green] 已应用设计灵感: {selected.name} ({selected.slug})")
+            self.console.print(f"  来源: {selected.source}")
+            self.console.print(f"  已写入配置: design_inspiration_slug = {selected.slug}")
+            self.console.print(f"  记录文件: {record_path}")
+
+            if getattr(args, "write_uiux", True):
+                return self._cmd_run_targeted_refresh("uiux")
+            return 0
 
         if args.design_command == "search":
             # 搜索设计资产
@@ -898,6 +1095,6 @@ class CliExperienceMixin:
 
         else:
             self.console.print("[yellow]请指定设计子命令[/yellow]")
-            self.console.print("  可用命令: search, generate, tokens, landing, chart, ux, stack, codegen")
+            self.console.print("  可用命令: list, recommend, apply, search, generate, tokens, landing, chart, ux, stack, codegen")
             self.console.print("  使用 'super-dev design <command> -h' 查看帮助")
             return 1

--- a/super_dev/cli_parser_mixin.py
+++ b/super_dev/cli_parser_mixin.py
@@ -1068,6 +1068,58 @@ class CliParserMixin:
             description="使用 'super-dev design <command> -h' 查看帮助",
         )
 
+        design_list_parser = design_subparsers.add_parser(
+            "list",
+            help="列出设计灵感锚点",
+            description="列出内置设计灵感库，供 UI/UX 方向选择与参考",
+        )
+        design_list_parser.add_argument("--product-type", help="产品类型过滤 (landing/saas/dashboard/content/ecommerce)")
+        design_list_parser.add_argument("--industry", help="行业过滤 (fintech/education/healthcare/general)")
+        design_list_parser.add_argument("--style", help="风格过滤 (minimal/professional/playful/luxury/modern)")
+        design_list_parser.add_argument("--frontend", help="前端栈过滤 (react/vue/next/uni-app/electron 等)")
+        design_list_parser.add_argument(
+            "-n", "--max-results", type=int, default=10, help="最大结果数 (默认: 10)"
+        )
+
+        design_recommend_parser = design_subparsers.add_parser(
+            "recommend",
+            help="推荐设计灵感锚点",
+            description="结合当前项目配置或需求描述，推荐最合适的设计灵感方向",
+        )
+        design_recommend_parser.add_argument(
+            "--idea", default="", help="显式需求描述；未提供时优先读取 super-dev.yaml 中的 description"
+        )
+        design_recommend_parser.add_argument("--product-type", help="显式指定产品类型")
+        design_recommend_parser.add_argument("--industry", help="显式指定行业")
+        design_recommend_parser.add_argument("--style", help="显式指定风格")
+        design_recommend_parser.add_argument("--frontend", help="显式指定前端栈")
+        design_recommend_parser.add_argument(
+            "-n", "--max-results", type=int, default=3, help="最大推荐数 (默认: 3)"
+        )
+
+        design_apply_parser = design_subparsers.add_parser(
+            "apply",
+            help="应用设计灵感锚点",
+            description="将指定设计灵感写入项目配置，并可同步重生成 uiux/ui-contract",
+        )
+        design_apply_parser.add_argument("slug", help="设计灵感 slug，例如 linear.app / vercel / stripe")
+        design_apply_parser.add_argument(
+            "--idea", default="", help="可选需求描述；仅在当前项目 description 为空时作为补充上下文"
+        )
+        design_apply_parser.add_argument(
+            "--write-uiux",
+            dest="write_uiux",
+            action="store_true",
+            help="应用后同步重生成 output/*-uiux.md 和 output/*-ui-contract.json（默认开启）",
+        )
+        design_apply_parser.add_argument(
+            "--no-write-uiux",
+            dest="write_uiux",
+            action="store_false",
+            help="仅写入配置与灵感记录，不重生成 UI 文档",
+        )
+        design_apply_parser.set_defaults(write_uiux=True)
+
         # design search
         design_search_parser = design_subparsers.add_parser(
             "search", help="搜索设计资产", description="搜索 UI 风格、配色、字体、组件等设计资产"

--- a/super_dev/config/manager.py
+++ b/super_dev/config/manager.py
@@ -46,6 +46,7 @@ class ProjectConfig:
     style_solution: str | None = None  # 样式方案
     state_management: list[str] = field(default_factory=list)  # 状态管理
     testing_frameworks: list[str] = field(default_factory=list)  # 测试框架
+    design_inspiration_slug: str = ""  # 显式设计灵感锚点
 
     # 领域知识
     domain: str = ""  # fintech, ecommerce, medical, social, iot, education
@@ -113,6 +114,16 @@ class ConfigManager:
         "language_preferences": [],
         "knowledge_allowed_domains": [],
         "knowledge_cache_ttl_seconds": 1800,
+        "phases": [
+            "discovery",
+            "intelligence",
+            "drafting",
+            "redteam",
+            "qa",
+            "delivery",
+            "deployment",
+        ],
+        "experts": ["PM", "ARCHITECT", "UI", "UX", "SECURITY", "CODE"],
         "quality_gate": 80,
         "host_compatibility_min_score": 80,
         "host_compatibility_min_ready_hosts": 1,
@@ -130,6 +141,7 @@ class ConfigManager:
         "style_solution": None,
         "state_management": [],
         "testing_frameworks": [],
+        "design_inspiration_slug": "",
     }
 
     def __init__(self, project_dir: Path | None = None):
@@ -169,11 +181,14 @@ class ConfigManager:
             loaded = yaml.safe_load(f)
         data = loaded if isinstance(loaded, dict) else {}
 
-        # Validate against schema (warnings only, not blocking)
+        # 合并默认配置
+        config_data: dict[str, Any] = {**self.DEFAULT_CONFIG, **data}
+
+        # Validate merged config (warnings only, not blocking)
         try:
             from .schema_validator import validate_config
 
-            schema_errors = validate_config(data)
+            schema_errors = validate_config(config_data)
             if schema_errors:
                 import logging
 
@@ -183,9 +198,6 @@ class ConfigManager:
                 )
         except Exception:
             pass
-
-        # 合并默认配置
-        config_data: dict[str, Any] = {**self.DEFAULT_CONFIG, **data}
 
         # 过滤掉 ProjectConfig 不支持的字段，避免 TypeError
         valid_fields = {f.name for f in dataclasses.fields(ProjectConfig)}

--- a/super_dev/config/schema_validator.py
+++ b/super_dev/config/schema_validator.py
@@ -27,10 +27,19 @@ KNOWN_FIELDS = {
     "knowledge_allowed_domains",
     "knowledge_cache_ttl_seconds",
     "language_preferences",
+    "ui_library",
+    "style_solution",
     "state_management",
     "testing_frameworks",
+    "design_inspiration_slug",
     "database",
     "author",
+    "execution_mode",
+    "overseer_enabled",
+    "codex_review_enabled",
+    "codex_review_phases",
+    "overseer_halt_on_critical",
+    "plan_failure_budget",
 }
 
 
@@ -102,6 +111,10 @@ def validate_config(config: dict) -> list[str]:
     ttl = config.get("knowledge_cache_ttl_seconds")
     if ttl is not None and (not isinstance(ttl, int) or ttl <= 0):
         errors.append("'knowledge_cache_ttl_seconds' must be a positive integer if present")
+
+    design_inspiration_slug = config.get("design_inspiration_slug")
+    if design_inspiration_slug is not None and not isinstance(design_inspiration_slug, str):
+        errors.append("'design_inspiration_slug' must be a string if present")
 
     return errors
 

--- a/super_dev/creators/document_generator.py
+++ b/super_dev/creators/document_generator.py
@@ -36,6 +36,7 @@ class DocumentGenerator(DocumentGeneratorContentMixin):
         style_solution: str | None = None,
         state_management: list[str] | None = None,
         testing_frameworks: list[str] | None = None,
+        design_inspiration_slug: str | None = None,
         language_preferences: list[str] | None = None,
         knowledge_summary: dict | None = None,
     ):
@@ -51,6 +52,7 @@ class DocumentGenerator(DocumentGeneratorContentMixin):
         self.style_solution = style_solution
         self.state_management = state_management or []
         self.testing_frameworks = testing_frameworks or []
+        self.design_inspiration_slug = str(design_inspiration_slug or "").strip()
         self.language_preferences = self._normalize_language_preferences(language_preferences)
         self.knowledge_summary: dict = knowledge_summary or {}
         self.expert_context: dict | None = None  # 专家视角注入（由 ExpertDispatcher 设置）

--- a/super_dev/creators/document_generator_content_mixin.py
+++ b/super_dev/creators/document_generator_content_mixin.py
@@ -209,6 +209,7 @@ const theme: ThemeConfig = {
             industry=analysis["industry"],
             style=analysis["style"],
             ui_library=self.ui_library,
+            preferred_design_reference_slug=getattr(self, "design_inspiration_slug", ""),
         )
 
     def _get_design_system_bundle(self, analysis: dict, profile: dict) -> dict:
@@ -264,6 +265,7 @@ const theme: ThemeConfig = {
                 "style": analysis.get("style", "modern"),
                 "platform": self.platform,
                 "frontend": self.frontend,
+                "design_inspiration_slug": getattr(self, "design_inspiration_slug", ""),
             },
             "style_direction": profile.get("style_direction", {}),
             "surface": profile.get("surface"),
@@ -279,6 +281,7 @@ const theme: ThemeConfig = {
             "banned_patterns": list(profile.get("banned_patterns", [])),
             "knowledge_keywords": list(profile.get("knowledge_keywords", [])),
             "design_references": list(profile.get("design_references", [])),
+            "selected_design_reference": profile.get("selected_design_reference"),
             "framework_playbook": profile.get("framework_playbook"),
             "color_palette": palette,
             "typography_preset": typography,
@@ -3023,6 +3026,12 @@ spec:
                     continue
                 lines.append(f"- **{item.get('name', 'N/A')}**: {item.get('rationale', 'N/A')}")
         references = profile.get("design_references", [])
+        selected_reference = (
+            profile.get("selected_design_reference")
+            if isinstance(profile.get("selected_design_reference"), dict)
+            else {}
+        )
+        selected_slug = str(selected_reference.get("slug", "")).strip()
         if references:
             lines.extend(["", "**设计参考锚点**:"])
             for item in references[:3]:
@@ -3030,8 +3039,9 @@ spec:
                     continue
                 signals = " / ".join(item.get("signals", [])[:3])
                 cautions = "；".join(item.get("cautions", [])[:2])
+                selected_tag = "（已选灵感）" if selected_slug and item.get("slug") == selected_slug else ""
                 lines.append(
-                    f"- **{item.get('name', 'N/A')}**: {item.get('rationale', 'N/A')} 参考信号：{signals or 'N/A'}。避免：{cautions or 'N/A'}"
+                    f"- **{item.get('name', 'N/A')}{selected_tag}**: {item.get('rationale', 'N/A')} 参考信号：{signals or 'N/A'}。避免：{cautions or 'N/A'}"
                 )
 
         lines.extend(["", "**明确不默认采用**:"])

--- a/super_dev/creators/prompt_templates.py
+++ b/super_dev/creators/prompt_templates.py
@@ -79,7 +79,7 @@ class PromptTemplateManager:
     """
 
     def __init__(self, templates_dir: str = "super_dev/templates") -> None:
-        self.templates_dir = Path(templates_dir)
+        self.templates_dir = self._resolve_templates_dir(templates_dir)
         self.templates: dict[str, PromptTemplate] = {}
         self._version_history: dict[str, list[dict]] = {}
         self._load_templates()
@@ -185,7 +185,18 @@ class PromptTemplateManager:
         # 同时尝试从 manifest.yaml 补充信息
         self._load_manifest()
 
-        logger.info("共加载 %d 个 Prompt 模板", len(self.templates))
+        logger.debug("共加载 %d 个 Prompt 模板", len(self.templates))
+
+    def _resolve_templates_dir(self, templates_dir: str) -> Path:
+        candidate = Path(templates_dir)
+        if candidate.is_absolute():
+            return candidate
+
+        cwd_candidate = Path.cwd() / candidate
+        if cwd_candidate.exists():
+            return cwd_candidate
+
+        return Path(__file__).resolve().parent.parent / "templates"
 
     def _parse_template_file(self, path: Path) -> PromptTemplate | None:
         """解析单个 Markdown 模板文件。

--- a/super_dev/design/__init__.py
+++ b/super_dev/design/__init__.py
@@ -31,7 +31,7 @@ from .tech_stack import (
     get_tech_stack_engine,
 )
 from .tokens import TokenGenerator
-from .ui_intelligence import LibraryRecommendation, UIIntelligenceAdvisor
+from .ui_intelligence import DesignReference, LibraryRecommendation, UIIntelligenceAdvisor
 from .ux_guide import UXGuideEngine, UXGuideline, UXRecommendation, get_ux_guide
 
 __all__ = [
@@ -45,6 +45,7 @@ __all__ = [
     "TokenGenerator",
     "UIIntelligenceAdvisor",
     "LibraryRecommendation",
+    "DesignReference",
     "LandingPatternGenerator",
     "LandingPattern",
     "CTAStrategy",

--- a/super_dev/design/ui_intelligence.py
+++ b/super_dev/design/ui_intelligence.py
@@ -1671,6 +1671,7 @@ class UIIntelligenceAdvisor:
         industry: str,
         style: str,
         ui_library: str | None = None,
+        preferred_design_reference_slug: str | None = None,
     ) -> dict[str, Any]:
         """生成 UI intelligence 推荐"""
         raw_frontend = frontend.lower().strip()
@@ -1782,15 +1783,15 @@ class UIIntelligenceAdvisor:
         if typo_key not in self.PRODUCT_TYPOGRAPHY_PRESETS:
             typo_key = industry if industry in self.PRODUCT_TYPOGRAPHY_PRESETS else "general"
         typography_preset = self.PRODUCT_TYPOGRAPHY_PRESETS.get(typo_key, self.PRODUCT_TYPOGRAPHY_PRESETS["general"])
-        design_references = [
-            item.to_dict()
-            for item in self._select_design_references(
-                product_type=product_type,
-                industry=industry,
-                style=style,
-                frontend=normalized_frontend,
-            )
-        ]
+        selected_reference = self.get_design_reference(preferred_design_reference_slug)
+        design_reference_items = self._select_design_references(
+            product_type=product_type,
+            industry=industry,
+            style=style,
+            frontend=normalized_frontend,
+            preferred_slug=selected_reference.slug if selected_reference else None,
+        )
+        design_references = [item.to_dict() for item in design_reference_items]
         framework_playbook = self._select_framework_playbook(
             raw_frontend=raw_frontend,
             normalized_frontend=normalized_frontend,
@@ -1821,9 +1822,71 @@ class UIIntelligenceAdvisor:
             "color_palette_dark": self.generate_dark_variant(color_palette),
             "typography_preset": typography_preset,
             "design_references": design_references,
+            "selected_design_reference": selected_reference.to_dict() if selected_reference else None,
             "framework_playbook": framework_playbook.to_dict() if framework_playbook else None,
             "pre_delivery_checklist": list(self.PRE_DELIVERY_CHECKLIST),
         }
+
+    def list_design_references(
+        self,
+        *,
+        product_type: str | None = None,
+        industry: str | None = None,
+        style: str | None = None,
+        frontend: str | None = None,
+        limit: int | None = None,
+    ) -> list[DesignReference]:
+        normalized_frontend = ""
+        if frontend:
+            raw_frontend = frontend.lower().strip()
+            normalized_frontend = self.FRONTEND_ALIASES.get(raw_frontend, raw_frontend)
+
+        scored: list[tuple[int, DesignReference]] = []
+        for item in self.DESIGN_REFERENCES:
+            if product_type and product_type not in item.fit_product_types:
+                continue
+            if industry and industry not in item.fit_industries:
+                continue
+            if style and style not in item.fit_styles:
+                continue
+            if normalized_frontend and normalized_frontend not in item.fit_frontends:
+                continue
+            score = item.priority
+            if product_type:
+                score += 5
+            if industry:
+                score += 3
+            if style:
+                score += 2
+            if normalized_frontend:
+                score += 2
+            scored.append((score, item))
+
+        if not scored:
+            scored = [(item.priority, item) for item in self.DESIGN_REFERENCES]
+
+        scored.sort(key=lambda pair: pair[0], reverse=True)
+        items = [item for _, item in scored]
+        if limit is not None:
+            return items[: max(limit, 0)]
+        return items
+
+    def get_design_reference(self, slug_or_name: str | None) -> DesignReference | None:
+        token = str(slug_or_name or "").strip().lower()
+        if not token:
+            return None
+
+        for item in self.DESIGN_REFERENCES:
+            aliases = {
+                item.slug.lower(),
+                item.slug.lower().replace(".", "-"),
+                item.slug.lower().split(".")[0],
+                item.name.lower(),
+                item.name.lower().replace(" ", "-"),
+            }
+            if token in aliases:
+                return item
+        return None
 
     def _select_design_references(
         self,
@@ -1833,6 +1896,7 @@ class UIIntelligenceAdvisor:
         style: str,
         frontend: str,
         limit: int = 3,
+        preferred_slug: str | None = None,
     ) -> list[DesignReference]:
         scored: list[tuple[int, DesignReference]] = []
         for item in self.DESIGN_REFERENCES:
@@ -1852,6 +1916,10 @@ class UIIntelligenceAdvisor:
 
         picked: list[DesignReference] = []
         seen: set[str] = set()
+        preferred = self.get_design_reference(preferred_slug)
+        if preferred is not None:
+            picked.append(preferred)
+            seen.add(preferred.slug)
         for _, item in scored:
             if item.slug in seen:
                 continue

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -1198,6 +1198,122 @@ class TestCLIReview:
             os.chdir(original_cwd)
 
 
+class TestCLIDesignInspiration:
+    def test_design_list_outputs_curated_inspirations(self, temp_project_dir: Path, capsys):
+        original_cwd = os.getcwd()
+        os.chdir(temp_project_dir)
+
+        try:
+            cli = SuperDevCLI()
+            result = cli.run(["design", "list", "--frontend", "react", "-n", "5"])
+
+            assert result == 0
+            output = capsys.readouterr().out
+            assert "设计灵感锚点" in output
+            assert "Linear" in output or "Vercel" in output
+        finally:
+            os.chdir(original_cwd)
+
+    def test_design_recommend_uses_project_context(self, temp_project_dir: Path, capsys):
+        original_cwd = os.getcwd()
+        os.chdir(temp_project_dir)
+
+        try:
+            with open(temp_project_dir / "super-dev.yaml", "w", encoding="utf-8") as f:
+                yaml.dump(
+                    {
+                        "name": "ops-suite",
+                        "description": "构建一个企业协作 SaaS 工作台",
+                        "platform": "web",
+                        "frontend": "react",
+                        "backend": "python",
+                    },
+                    f,
+                    allow_unicode=True,
+                )
+
+            cli = SuperDevCLI()
+            result = cli.run(["design", "recommend"])
+
+            assert result == 0
+            output = capsys.readouterr().out
+            assert "设计灵感推荐" in output
+            assert "Linear" in output
+        finally:
+            os.chdir(original_cwd)
+
+    def test_design_recommend_accepts_minimal_config_without_schema_warning(
+        self, temp_project_dir: Path, capsys
+    ):
+        original_cwd = os.getcwd()
+        os.chdir(temp_project_dir)
+
+        try:
+            with open(temp_project_dir / "super-dev.yaml", "w", encoding="utf-8") as f:
+                yaml.dump(
+                    {
+                        "name": "minimal-site",
+                        "description": "商业级 SaaS 官网",
+                        "frontend": "react",
+                        "backend": "node",
+                        "platform": "web",
+                    },
+                    f,
+                    allow_unicode=True,
+                )
+
+            cli = SuperDevCLI()
+            result = cli.run(["design", "recommend"])
+
+            assert result == 0
+            output = capsys.readouterr().out
+            assert "Config schema validation warnings" not in output
+            assert "设计灵感推荐" in output
+        finally:
+            os.chdir(original_cwd)
+
+    def test_design_apply_updates_config_and_regenerates_uiux(self, temp_project_dir: Path):
+        original_cwd = os.getcwd()
+        os.chdir(temp_project_dir)
+
+        try:
+            with open(temp_project_dir / "super-dev.yaml", "w", encoding="utf-8") as f:
+                yaml.dump(
+                    {
+                        "name": "brand-site",
+                        "description": "为一个商业级 SaaS 产品生成官方网站和产品页",
+                        "platform": "web",
+                        "frontend": "react",
+                        "backend": "node",
+                    },
+                    f,
+                    allow_unicode=True,
+                )
+
+            cli = SuperDevCLI()
+            result = cli.run(["design", "apply", "vercel"])
+
+            assert result == 0
+
+            config = yaml.safe_load((temp_project_dir / "super-dev.yaml").read_text(encoding="utf-8"))
+            assert config["design_inspiration_slug"] == "vercel"
+
+            output_dir = temp_project_dir / "output"
+            uiux_path = output_dir / "brand-site-uiux.md"
+            contract_path = output_dir / "brand-site-ui-contract.json"
+            inspiration_path = output_dir / "brand-site-design-inspiration.json"
+
+            assert uiux_path.exists()
+            assert contract_path.exists()
+            assert inspiration_path.exists()
+
+            contract = json.loads(contract_path.read_text(encoding="utf-8"))
+            assert contract["selected_design_reference"]["slug"] == "vercel"
+            assert contract["design_references"][0]["slug"] == "vercel"
+        finally:
+            os.chdir(original_cwd)
+
+
 class TestCLIQuality:
     """测试 quality 命令"""
 
@@ -1856,6 +1972,11 @@ class TestCLISkillAndIntegrate:
     def test_doctor_prints_multiple_host_precondition_items_for_codex(
         self, temp_project_dir: Path, capsys
     ):
+        fake_home = temp_project_dir / "fake-home"
+        fake_home.mkdir(parents=True, exist_ok=True)
+        (fake_home / ".codex").mkdir(parents=True, exist_ok=True)
+        original_home = os.environ.get("HOME")
+        os.environ["HOME"] = str(fake_home)
         original_cwd = os.getcwd()
         os.chdir(temp_project_dir)
         try:
@@ -1869,11 +1990,19 @@ class TestCLISkillAndIntegrate:
             assert "需在目标项目/工作区内触发" in output
             assert "关闭旧会话并新开一个宿主会话" in output
         finally:
+            if original_home is None:
+                os.environ.pop("HOME", None)
+            else:
+                os.environ["HOME"] = original_home
             os.chdir(original_cwd)
 
     def test_doctor_json_includes_runtime_install_health(
         self, temp_project_dir: Path, monkeypatch, capsys
     ):
+        fake_home = temp_project_dir / "fake-home"
+        fake_home.mkdir(parents=True, exist_ok=True)
+        (fake_home / ".codex").mkdir(parents=True, exist_ok=True)
+        monkeypatch.setenv("HOME", str(fake_home))
         original_cwd = os.getcwd()
         os.chdir(temp_project_dir)
         try:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -89,6 +89,27 @@ class TestConfigManager:
         assert config.platform == "desktop"
         assert config.quality_gate == 85
 
+    def test_load_minimal_file_does_not_emit_schema_warning(self, temp_project_dir: Path, caplog):
+        config_data = {
+            "name": "minimal-project",
+            "platform": "web",
+            "frontend": "react",
+            "backend": "node",
+        }
+        config_path = temp_project_dir / "super-dev.yaml"
+        with open(config_path, "w") as f:
+            yaml.dump(config_data, f)
+
+        caplog.clear()
+        caplog.set_level("WARNING", logger="super_dev.config")
+
+        manager = ConfigManager(temp_project_dir)
+        config = manager.load()
+
+        assert config.name == "minimal-project"
+        assert config.quality_gate == 80
+        assert not any("Config schema validation warnings" in record.message for record in caplog.records)
+
     def test_save_config(self, temp_project_dir: Path):
         """测试保存配置"""
         manager = ConfigManager(temp_project_dir)

--- a/tests/unit/test_prompt_templates.py
+++ b/tests/unit/test_prompt_templates.py
@@ -100,6 +100,11 @@ class TestPromptTemplate:
 # ---------------------------------------------------------------------------
 
 class TestManagerLoading:
+    def test_default_relative_dir_resolves_to_package_templates(self):
+        mgr = PromptTemplateManager()
+        assert mgr.templates_dir.name == "templates"
+        assert mgr.templates_dir.exists()
+
     def test_empty_dir(self, tmp_path: Path):
         mgr = PromptTemplateManager(str(tmp_path))
         assert len(mgr.templates) == 0

--- a/tests/unit/test_requirement_parser.py
+++ b/tests/unit/test_requirement_parser.py
@@ -151,6 +151,22 @@ class TestDocumentGeneratorIntegration:
         assert contract["design_tokens"]["css_variables"]
         assert contract["typography_preset"]["heading"]
 
+    def test_document_generator_prefers_explicit_design_inspiration(self):
+        generator = DocumentGenerator(
+            name="brand-site",
+            description="为一个商业级 SaaS 产品生成官方网站和产品页",
+            frontend="react",
+            backend="node",
+            design_inspiration_slug="vercel",
+        )
+
+        contract = generator.generate_ui_contract()
+        uiux = generator.generate_uiux()
+
+        assert contract["selected_design_reference"]["slug"] == "vercel"
+        assert contract["design_references"][0]["slug"] == "vercel"
+        assert "Vercel（已选灵感）" in uiux
+
     def test_document_generator_emits_uniapp_framework_playbook(self):
         generator = DocumentGenerator(
             name="uni-shop",


### PR DESCRIPTION
## Summary
- add `super-dev design list / recommend / apply` for DESIGN.md-inspired design exploration
- persist the selected design inspiration into project config and regenerate `uiux.md` / `ui-contract.json`
- fix related config, prompt-template path, and doctor test isolation issues so the CLI flow stays clean

## Why
Super Dev already had strong internal UI truth sources in `output/*-uiux.md` and `output/*-ui-contract.json`, but it lacked a lightweight inspiration layer for users who want to start from recognizable product aesthetics like Vercel, Linear, or Stripe. This change adds that inspiration workflow without introducing a second design source of truth.

## What changed
- added curated design inspiration listing and recommendation in the existing `design` command group
- added `design apply <slug>` to store `design_inspiration_slug` and write `output/*-design-inspiration.json`
- wired explicit inspiration choice into `DocumentGenerator`, UI intelligence selection, UI/UX document output, and UI contract generation
- fixed config loading so minimal `super-dev.yaml` files do not emit false schema warnings
- fixed prompt template path resolution so CLI usage does not depend on current working directory layout
- isolated `doctor --repair` Codex tests from the real HOME directory

## User impact
- users can browse built-in design inspirations
- users can get recommendations from current project context
- users can apply a chosen inspiration and immediately regenerate the project's UI documents and contract
- Super Dev still keeps `uiux.md + ui-contract.json` as the internal source of truth

## Validation
- `python3 -m pytest tests/unit/test_prompt_templates.py tests/unit/test_config.py tests/unit/test_requirement_parser.py tests/unit/test_ui_intelligence.py tests/integration/test_cli.py tests/integration/test_web_api.py -q`
- result: `419 passed`
- manual smoke validated `design list`, `design recommend`, and `design apply vercel`
- API health check after restart: `http://127.0.0.1:8001/api/health` -> `{"status":"healthy","version":"2.3.7"}`

## Notes
- this PR is intentionally opened as a draft
- the change keeps the existing UI review and quality gate model intact rather than replacing it with raw external DESIGN.md files